### PR TITLE
Completion descriptions

### DIFF
--- a/plugin/deoplete-jedi.vim
+++ b/plugin/deoplete-jedi.vim
@@ -10,3 +10,11 @@ endif
 if !exists("g:deoplete#sources#jedi#enable_cache")
   let g:deoplete#sources#jedi#enable_cache = get(g:, 'deoplete#sources#jedi#enable_cache', 1)
 endif
+
+if !exists("g:deoplete#sources#jedi#debug_enabled")
+  let g:deoplete#sources#jedi#debug_enabled = get(g:, 'deoplete#sources#jedi#debug_enabled', 0)
+endif
+
+if !exists("g:deoplete#sources#jedi#short_types")
+  let g:deoplete#sources#jedi#short_types = get(g:, 'deoplete#sources#jedi#short_types', 0)
+endif


### PR DESCRIPTION
Closes #18 

The completion menu results should be pretty good now.  Many of the `kind` strings are shortened to a maximum of 5 characters and are aliased to be less ambiguous.  `g:deoplete#sources#jedi#statement_length` is now used to only shorten function signatures.

`g:deoplete#sources#jedi#statement_length = 0` - Zero value means it's disabled and the full function is shown.
![screen-shot-2016-03-18-22-54-19](https://cloud.githubusercontent.com/assets/111942/13896310/90302830-ed5d-11e5-8765-65341a57f757.png)

`g:deoplete#sources#jedi#statement_length = 50` - It first removes `kwarg` default values to shorten it first.  If it's still too long, it will remove args until it's short enough.
![screen-shot-2016-03-18-22-56-06](https://cloud.githubusercontent.com/assets/111942/13896314/ab42a454-ed5d-11e5-8be0-77fdb8bc117a.png)

`g:deoplete#sources#jedi#statement_length = 1` - Impossible value, but makes it so that all function args are removed and replaced with `...`
![screen-shot-2016-03-18-22-55-13](https://cloud.githubusercontent.com/assets/111942/13896325/f68ce186-ed5d-11e5-9e72-041832ddaddd.png)

deoplete-jedi can distinguish properties from functions:
![screen-shot-2016-03-18-22-56-34](https://cloud.githubusercontent.com/assets/111942/13896329/0cfeb4e4-ed5e-11e5-84c7-aff4ff2fe1be.png)
