### PR TITLE
Option for showing doc-string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Plug 'zchee/deoplete-jedi'
   used instead.  Default: `50`
 - `deoplete#sources#jedi#enable_cache`: Enables caching of completions for
   faster results.  Default: `1`
+- `deoplete#sources#jedi#show_docstring`: Shows docstring in preview window.  Default: `0`
 
 
 ## Virtual Environments

--- a/plugin/deoplete-jedi.vim
+++ b/plugin/deoplete-jedi.vim
@@ -18,3 +18,6 @@ let g:deoplete#sources#jedi#statement_length =
 
 let g:deoplete#sources#jedi#debug_enabled =
       \ get(g:, 'deoplete#sources#jedi#debug_enabled', 0)
+
+let g:deoplete#sources#jedi#show_docstring =
+      \ get(g:, 'deoplete#sources#jedi#show_docstring', 0)

--- a/rplugin/python3/deoplete/sources/deoplete_jedi.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi.py
@@ -71,6 +71,9 @@ class Source(Base):
         self.cache_enabled = \
             self.vim.vars['deoplete#sources#jedi#enable_cache']
 
+        self.show_docstring = \
+            self.vim.vars['deoplete#sources#jedi#show_docstring']
+
         self.complete_min_length = \
             self.vim.vars['deoplete#auto_complete_start_length']
 
@@ -187,7 +190,13 @@ class Source(Base):
                 return (name, builtin_type, '', '')
 
         if type_ == 'class' and desc.startswith('builtins.'):
-            return (name, type_) + self.call_signature(comp)
+            if self.show_docstring:
+                return (name,
+                        type_,
+                        comp.docstring(),
+                        self.call_signature(comp)[1])
+            else:
+                return (name, type_) + self.call_signature(comp)
 
         if type_ == 'function':
             if comp.module_path not in cache and comp.line and comp.line > 1:
@@ -205,7 +214,13 @@ class Source(Base):
                     if line.startswith('@property'):
                         return (name, 'property', desc, '')
                     i -= 1
-            return (name, type_) + self.call_signature(comp)
+            if self.show_docstring:
+                return (name,
+                        type_,
+                        comp.docstring(),
+                        self.call_signature(comp)[1])
+            else:
+                return (name, type_) + self.call_signature(comp)
 
         # self.debug('Unhandled: %s, Type: %s, Desc: %s', comp.name, type_, desc)
         return (name, type_, '', '')


### PR DESCRIPTION
From call_signature function doc-string I guess that not showing doc-string in preview window was conscious choice. I for one found those useful and was a bit disappointed to not find them here after coming from jedi-vim.

This PR would add option for user to specify if they want to have doc-strings shown in theirs preview window. With default value being no doc-string.