### PR TITLE
Use a server for Jedi completions

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
@@ -1,0 +1,83 @@
+import os
+import re
+
+
+def split_module(text, default_value=None):
+    """Utility to split the module text.
+
+    If there is nothing to split, return `default_value`.
+    """
+    m = re.search('([\w_\.]+)$', text)
+    if m and '.' in m.group(1):
+        return m.group(1).rsplit('.', 1)[0]
+    return default_value
+
+
+def cache_context(filename, context):
+    """Caching based on context input.
+
+    If the input is blank, it was triggered with `.` to get module completions.
+
+    The module files as reported by Jedi are stored with their modification
+    times to help detect if a cache needs to be refreshed.
+
+    For scoped variables in the buffer, construct a cache key using the
+    filename.  The buffer file's modification time is checked to see if the
+    completion needs to be refreshed.  The approximate scope lines are cached
+    to help invalidate the cache based on line position.
+    """
+    line = context['position'][1]
+    deoplete_input = context['input'].strip()
+    cache_key = None
+    extra_modules = []
+    cache_line = 0
+
+    if deoplete_input.startswith(('import ', 'from ')):
+        # Cache imports with buffer filename as the key prefix.
+        # For `from` imports, the first part of the statement is
+        # considered to be the same as `import` for caching.
+        suffix = 'import'
+
+        # The trailing whitespace is significant for caching imports.
+        import_line = context['input'].lstrip()
+
+        if import_line.startswith('import'):
+            m = re.search(r'^import\s+(\S+)$', import_line)
+        else:
+            m = re.search(r'^from\s+(\S+)\s+import\s+', import_line)
+            if m:
+                # Treat the first part of the import as a cached
+                # module, but cache it per-buffer.
+                cache_key = '{}.from.{}'.format(filename, m.group(1))
+            else:
+                m = re.search(r'^from\s+(\S+)$', import_line)
+
+        if not cache_key:
+            if m:
+                suffix = split_module(m.group(1), suffix)
+                cache_key = '{}.import.{}'.format(filename, suffix)
+                if os.path.exists(filename):
+                    extra_modules.append(filename)
+
+    if not cache_key:
+        # Find a cacheable key first
+        cache_key = split_module(deoplete_input)
+        if cache_key:
+            if cache_key.startswith('self'):
+                # TODO: Get class lines and cache these differently
+                # based on cursor position.
+                # Cache `self.`, but monitor buffer file's modification
+                # time.
+                if os.path.exists(filename):
+                    extra_modules.append(filename)
+                cache_key = '{}.{}'.format(filename, cache_key)
+                cache_line = line - 1
+                os.path
+        elif context.get('complete_str'):
+            # Note: Module completions will be an empty string.
+            cache_key = filename
+            if os.path.exists(filename):
+                extra_modules.append(filename)
+            cache_line = line - 1
+
+    return cache_key, cache_line, extra_modules

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/server.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/server.py
@@ -1,0 +1,307 @@
+"""Jedi mini server for deoplete-jedi
+
+This script allows Jedi to run using the Python interpreter that is found in
+the user's environment instead of the one Neovim is using.
+
+Jedi seems to accumulate latency with each completion.  To deal with this, the
+server is restarted after 50 completions.  This threshold is relatively high
+considering that deoplete-jedi caches completion results.  These combined
+should make deoplete-jedi's completions pretty fast and responsive.
+"""
+from __future__ import unicode_literals
+
+import os
+import sys
+import struct
+import argparse
+import subprocess
+import logging
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler)
+
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+jedi_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'jedi')
+
+# Type mapping.  Empty values will use the key value instead.
+# Keep them 5 characters max to minimize required space to display.
+_types = {
+    'import': 'imprt',
+    'class': '',
+    'function': 'def',
+    'globalstmt': 'var',
+    'instance': 'var',
+    'statement': 'var',
+    'keyword': 'keywd',
+    'module': 'mod',
+    'param': 'arg',
+    'property': 'prop',
+
+    'bool': '',
+    'bytes': 'byte',
+    'complex': 'cmplx',
+    'dict': '',
+    'list': '',
+    'float': '',
+    'int': '',
+    'object': 'obj',
+    'set': '',
+    'slice': '',
+    'str': '',
+    'tuple': '',
+    'mappingproxy': 'dict',  # cls.__dict__
+    'member_descriptor': 'cattr',
+    'getset_descriptor': 'cprop',
+    'method_descriptor': 'cdef',
+}
+
+
+class StreamError(Exception):
+    """Error in reading/writing streams."""
+
+
+class StreamEmpty(StreamError):
+    """Empty stream data"""
+
+
+def stream_read(pipe):
+    """Read data from the pipe."""
+    buffer = getattr(pipe, 'buffer', pipe)
+    header = buffer.read(4)
+    if not header:
+        raise StreamEmpty
+
+    if len(header) < 4:
+        raise StreamError('Incorrect byte length')
+
+    length = struct.unpack('I', header)[0]
+    data = buffer.read(length)
+    if len(data) < length:
+        raise StreamError('Got less data than expected')
+    return pickle.loads(data)
+
+
+def stream_write(pipe, obj):
+    """Write data to the pipe."""
+    data = pickle.dumps(obj, 2)
+    header = struct.pack('I', len(data))
+    buffer = getattr(pipe, 'buffer', pipe)
+    buffer.write(header + data)
+    pipe.flush()
+
+
+class Server(object):
+    """Server class
+
+    This is created when this script is ran directly.
+    """
+    def __init__(self, desc_len=0, short_types=False, show_docstring=False):
+        self.desc_len = desc_len
+        self.use_short_types = short_types
+        self.show_docstring = show_docstring
+
+    def _loop(self):
+        import jedi
+        while True:
+            data = stream_read(sys.stdin)
+            if not isinstance(data, tuple):
+                break
+            source, line, col, filename = data
+            log.debug('Line: %r, Col: %r, Filename: %r', line, col, filename)
+            completions = jedi.Script(source, line, col, filename).completions()
+            out = []
+            tmp_filecache = {}
+            for c in completions:
+                name, type_, desc, abbr = self.parse_completion(c, tmp_filecache)
+                kind = type_ if not self.use_short_types \
+                    else _types.get(type_) or type_
+                out.append((c.module_path, name, type_, desc, abbr, kind))
+            stream_write(sys.stdout, out)
+
+    def run(self):
+        log.debug(sys.path)
+        try:
+            self._loop()
+        except StreamEmpty:
+            log.debug('Input closed')
+        except Exception:
+            log.exception('exception')
+
+    def call_signature(self, comp):
+        """Construct the function's call signature.
+
+        comp.docstring() is not reliable and we don't need the entire
+        docstring.
+
+        Returns a tuple of (full, abbr) call signatures.
+        """
+        params = []
+        params_abbr = []
+        try:
+            # Total length includes parenthesis
+            length = len(comp.name)
+            for i, p in enumerate(comp.params):
+                desc = p.description.strip()
+                if i == 0 and desc == 'self':
+                    continue
+
+                if '\\n' in desc:
+                    desc = desc.replace('\\n', '\\x0A')
+
+                length += len(desc) + 2
+                params.append(desc)
+
+            params_abbr = params[:]
+            if self.desc_len > 0:
+                if length > self.desc_len:
+                    # First remove all keyword params to see if that makes it
+                    # short enough.
+                    params_abbr = [x.split('=', 1)[0] for x in params_abbr]
+                    length = len(comp.name) + sum([len(x) + 2
+                                                   for x in params_abbr])
+
+                while length + 3 > self.desc_len \
+                        and len(params_abbr):
+                    # Keep removing params until short enough.
+                    length -= len(params_abbr[-1]) - 3
+                    params_abbr = params_abbr[:-1]
+                if len(params) > len(params_abbr):
+                    params_abbr.append('...')
+        except AttributeError:
+            pass
+
+        return ('{}({})'.format(comp.name, ', '.join(params)),
+                '{}({})'.format(comp.name, ', '.join(params_abbr)))
+
+    def parse_completion(self, comp, cache):
+        """Return a tuple describing the completion.
+
+        Returns (name, type, description, abbreviated)
+        """
+        name = comp.name
+        type_, desc = [x.strip() for x in comp.description.split(':', 1)]
+
+        if type_ == 'instance' and desc.startswith(('builtins.', 'posix.')):
+            # Simple description
+            builtin_type = desc.rsplit('.', 1)[-1]
+            if builtin_type in _types:
+                return (name, builtin_type, '', '')
+
+        if type_ == 'class' and desc.startswith('builtins.'):
+            if self.show_docstring:
+                return (name,
+                        type_,
+                        comp.docstring(),
+                        self.call_signature(comp)[1])
+            else:
+                return (name, type_) + self.call_signature(comp)
+
+        if type_ == 'function':
+            if comp.module_path not in cache and comp.line and comp.line > 1 \
+                    and os.path.exists(comp.module_path):
+                with open(comp.module_path, 'r') as fp:
+                    cache[comp.module_path] = fp.readlines()
+            lines = cache.get(comp.module_path)
+            if isinstance(lines, list) and len(lines) > 1 \
+                    and comp.line < len(lines) and comp.line > 1:
+                # Check the function's decorators to check if it's decorated
+                # with @property
+                i = comp.line - 2
+                while i >= 0:
+                    line = lines[i].lstrip()
+                    if not line.startswith('@'):
+                        break
+                    if line.startswith('@property'):
+                        return (name, 'property', desc, '')
+                    i -= 1
+            if self.show_docstring:
+                return (name,
+                        type_,
+                        comp.docstring(),
+                        self.call_signature(comp)[1])
+            else:
+                return (name, type_) + self.call_signature(comp)
+
+        return (name, type_, '', '')
+
+
+class Client(object):
+    """Client object
+
+    This will be used by deoplete-jedi to interact with the server.
+    """
+    max_completion_count = 50
+
+    def __init__(self, desc_len=0, short_types=False, show_docstring=False,
+                 debug=False):
+        self._server = None
+        self._count = 0
+        self.env = os.environ.copy()
+        self.env.update({
+            'PYTHONPATH': jedi_path,
+        })
+
+        if 'VIRTUAL_ENV' in os.environ:
+            self.env['VIRTUAL_ENV'] = os.getenv('VIRTUAL_ENV')
+
+        self.cmd = ['python', '-u', __file__, '--desc-length', str(desc_len)]
+        if short_types:
+            self.cmd.append('--short-types')
+        if show_docstring:
+            self.cmd.append('--docstrings')
+        if debug:
+            self.cmd.append('--debug')
+
+        self.restart()
+
+    def shutdown(self):
+        """Shut down the server."""
+        if self._server is not None and self._server.returncode is None:
+            # Closing the server's stdin will cause it to exit.
+            self._server.stdin.close()
+
+    def restart(self):
+        """Start or restart the server
+
+        If a server is already running, shut it down.
+        """
+        self.shutdown()
+        self._server = subprocess.Popen(self.cmd, stdin=subprocess.PIPE,
+                                        stdout=subprocess.PIPE, env=self.env)
+
+    def completions(self, *args):
+        """Get completions from the server.
+
+        If the number of completions already performed reaches a threshold,
+        restart the server.
+        """
+        if self._count > self.max_completion_count:
+            self._count = 0
+            self.restart()
+
+        self._count += 1
+        stream_write(self._server.stdin, args)
+        return stream_read(self._server.stdout)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--desc-length', type=int)
+    parser.add_argument('--short-types', action='store_true')
+    parser.add_argument('--docstrings', action='store_true')
+    parser.add_argument('--debug', action='store_true')
+    args = parser.parse_args()
+
+    if args.debug:
+        log.removeHandler(logging.NullHandler)
+        handler = logging.FileHandler('/tmp/jedi-server.log')
+        handler.setLevel(logging.DEBUG)
+        log.addHandler(handler)
+        log.setLevel(logging.DEBUG)
+
+    s = Server(args.desc_length, args.short_types, args.docstrings)
+    s.run()


### PR DESCRIPTION
Reference: #23

This is currently a proof of concept for a Jedi server that uses the shell's Python interpreter.  It still needs work.

The server is a subprocess that communicates via stdin/stdout.  I chose to not use TCP ports because the process interaction is managed internally and I didn't want to deal with port security.  It has potential to deadlock if the data packet is not formatted correctly.

It seems that Jedi's performance slowly degrades over time.  So, the server is forced to restart after it's handled 50 completions.  This number is not based on anything and will probably need to be tuned.  Measuring average completion time might be a better way for determining when it needs to restart.

The server needs to restart if the shell's virtualenv changes while deoplete-jedi is running.  We would need to see the use cases for this to come up with a way to monitor for virtualenv changes.