### PR TITLE
Use worker threads to for background completions

### DIFF
--- a/plugin/deoplete-jedi.vim
+++ b/plugin/deoplete-jedi.vim
@@ -7,9 +7,6 @@ let g:loaded_deoplete_jedi = 1
 let g:deoplete#sources#go#align_class =
       \ get( g:, 'deoplete#sources#go#align_class', 0 )
 
-let g:deoplete#sources#jedi#enable_cache =
-      \ get(g:, 'deoplete#sources#jedi#enable_cache', 1)
-
 let g:deoplete#sources#jedi#short_types =
       \ get(g:, 'deoplete#sources#jedi#short_types', 0)
 
@@ -21,3 +18,8 @@ let g:deoplete#sources#jedi#debug_enabled =
 
 let g:deoplete#sources#jedi#show_docstring =
       \ get(g:, 'deoplete#sources#jedi#show_docstring', 0)
+
+" Only one worker is really needed since deoplete-jedi has a pretty aggressive
+" cache.  Two workers may be needed if working with very large source files.
+let g:deoplete#sources#jedi#worker_threads =
+      \ get(g:, 'deoplete#sources#jedi#worker_threads', 1)

--- a/rplugin/python3/deoplete/sources/deoplete_jedi.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi.py
@@ -1,30 +1,34 @@
 import os
 import re
 import sys
+import time
 
 sys.path.insert(1, os.path.dirname(__file__))
 
+from deoplete_jedi import cache, worker, profiler
 from deoplete.sources.base import Base
-from deoplete_jedi import server
-from deoplete_jedi.cache import cache_context
 
-_block_re = re.compile(r'^\s*(def|class)\s')
+
+def sort_key(item):
+    w = item.get('word')
+    l = len(w)
+    z = l - len(w.lstrip('_'))
+    return (('z' * z) + w.lower()[z:], len(w))
 
 
 class Source(Base):
 
     def __init__(self, vim):
         Base.__init__(self, vim)
-        self.cache = {}
         self.name = 'jedi'
         self.mark = '[jedi]'
         self.rank = 500
         self.filetypes = ['python']
-        self.input_pattern = (r'[^. \t0-9]\.\w*$|'
+        self.input_pattern = (r'[\w\)\]\}\'\"]+\.\w*$|'
+                              r'\w+\s*=\s*\w*$|'
                               r'^\s*@\w*$|'
-                              r'^\s*from\s.+import \w*|'
-                              r'^\s*from \w*|'
-                              r'^\s*import \w*')
+                              r'^\s*from\s+[\w\.]*(?:\s+import\s+(?:\w*(?:,\s*)?)*)?|'
+                              r'^\s*import\s+(?:[\w\.]*(?:,\s*)?)*')
 
         self.debug_enabled = \
             self.vim.vars['deoplete#sources#jedi#debug_enabled']
@@ -35,46 +39,55 @@ class Source(Base):
         self.use_short_types = \
             self.vim.vars['deoplete#sources#jedi#short_types']
 
-        self.cache_enabled = \
-            self.vim.vars['deoplete#sources#jedi#enable_cache']
-
         self.show_docstring = \
             self.vim.vars['deoplete#sources#jedi#show_docstring']
 
         self.complete_min_length = \
             self.vim.vars['deoplete#auto_complete_start_length']
 
-        self._client = server.Client(self.description_length,
-                                     self.use_short_types, self.show_docstring,
-                                     self.debug_enabled)
+        self.worker_threads = \
+            self.vim.vars['deoplete#sources#jedi#worker_threads']
+
+        self.workers_started = False
+        self.boilerplate = []  # Completions that are included in all results
 
     def get_complete_position(self, context):
-        m = re.search(r'\w*$', context['input'])
+        pattern = r'\w*$'
+        if context['input'].lstrip().startswith(('from ', 'import ')):
+            m = re.search(r'[,\s]$', context['input'])
+            if m:
+                return m.end()
+        m = re.search(pattern, context['input'])
         return m.start() if m else -1
 
-    def indent_bounds(self, line, source):
-        """Gets the bounds for a Python block.
-
-        Only search for def or class for context.  Jedi only returns results
-        from the lines before the current one.
-        """
-        start = line - 1
-        indent = len(source[start]) - len(source[start].lstrip())
-
-        for i in range(start, 0, -1):
-            s_line = source[i]
-            if not s_line.strip() or not _block_re.match(s_line):
+    def mix_boilerplate(self, completions):
+        seen = set()
+        for item in self.boilerplate + completions:
+            if item['word'] in seen:
                 continue
+            seen.add(item['word'])
+            yield item
 
-            line_indent = len(s_line) - len(s_line.lstrip())
-            if line_indent < indent:
-                start = i
-                indent = line_indent
-                break
-
-        return [start, line - 1]
-
+    @profiler.profile
     def gather_candidates(self, context):
+        if not self.workers_started:
+            worker.start(max(1, self.worker_threads), self.description_length,
+                         self.use_short_types, self.show_docstring,
+                         self.debug_enabled)
+            cache.start_background(worker.comp_queue)
+            self.workers_started = True
+
+        refresh_boilerplate = False
+        if not self.boilerplate:
+            bp = cache.retrieve(('boilerplate~',))
+            if bp:
+                self.boilerplate = bp.completions[:]
+                refresh_boilerplate = True
+            else:
+                # This should be the first time any completion happened, so
+                # `wait` will be True.
+                worker.work_queue.put((('boilerplate~',), [], '', 1, 0, ''))
+
         line = context['position'][1]
         col = context['complete_position']
         buf = self.vim.current.buffer
@@ -82,7 +95,9 @@ class Source(Base):
 
         extra_modules = []
         cache_key = None
-        cache_line = 0
+        cached = None
+        refresh = True
+        wait = False
 
         # Inclusion filters for the results
         filters = []
@@ -92,69 +107,60 @@ class Source(Base):
             # If starting an import, only show module results
             filters.append('module')
 
-        if self.cache_enabled:
-            cache_key, cache_line, extra_modules = cache_context(buf.name,
-                                                                 context)
+        cache_key, extra_modules = cache.cache_context(buf.name, context, src)
+        cached = cache.retrieve(cache_key)
+        if cached and not cached.refresh:
+            modules = cached.modules
+            if all([filename in modules for filename in extra_modules]) \
+                    and all([int(os.path.getmtime(filename)) == mtime
+                             for filename, mtime in modules.items()]):
+                # The cache is still valid
+                refresh = False
 
-            if cache_key and cache_key in self.cache:
-                # XXX: Hash cache keys to reduce length?
-                cached = self.cache.get(cache_key)
-                lines = cached.get('lines', [0, 0])
-                modules = cached.get('modules')
-                # TODO: If cache is invalid, return stale results and start
-                # a thread to refresh.
-                if cache_line >= lines[0] and cache_line <= lines[1] \
-                        and all([filename in modules for filename in
-                                 extra_modules]) \
-                        and all([int(os.path.getmtime(filename)) == mtime
-                                 for filename, mtime in modules.items()]):
-                    out = cached.get('completions', [])
-                    if filters:
-                        return [x for x in out if x['$type'] in filters]
-                    return out
+        if cache_key and (cache_key[-1] in ('dot', 'vars', 'import', 'import~') or
+                          (cached and cache_key[-1] == 'package' and
+                           not len(cached.modules))):
+            # Always refresh scoped variables and module imports.  Additionally
+            # refresh cached items that did not have associated module files.
+            refresh = True
 
-        try:
-            completions = self._client.completions('\n'.join(src), line, col,
-                                                   str(buf.name))
-        except Exception:
-            return []
+        if (not cached or refresh) and cache_key and cache_key[-1] == 'package':
+            # Make a synthetic completion for a module to guarantee the correct
+            # completions.
+            src = ['from {} import '.format(cache_key[0])]
+            self.debug('source: %r', src)
+            line = 1
+            col = len(src[0])
 
-        out = []
-        modules = {f: int(os.path.getmtime(f)) for f in extra_modules}
-        for c in completions:
-            module_path, name, type_, desc, abbr, kind = c
-            if module_path and module_path not in modules \
-                    and os.path.exists(module_path):
-                modules[module_path] = int(os.path.getmtime(module_path))
+        if cached is None:
+            wait = True
 
-            out.append({
-                '$type': type_,
-                'word': name,
-                'abbr': abbr,
-                'kind': kind,
-                'info': desc,
-                'menu': self.mark + ' ',
-                'dup': 1,
-            })
+        self.debug('Key: %r, Refresh: %r, Wait: %r', cache_key, refresh, wait)
+        if cache_key and (not cached or refresh):
+            n = time.time()
+            worker.work_queue.put((cache_key, extra_modules, '\n'.join(src),
+                                   line, col, str(buf.name)))
+            while wait and time.time() - n < 2:
+                cached = cache.retrieve(cache_key)
+                if cached and cached.time >= n:
+                    break
+                time.sleep(0.01)
 
-        if cache_key:
-            lines = [0, 0]
-            if cache_line:
-                lines = self.indent_bounds(line, src)
+        if refresh_boilerplate:
+            # This should only occur the first time completions happen.
+            # Refresh the boilerplate to ensure it's always up to date (just in
+            # case).
+            self.debug('Refreshing boilerplate')
+            worker.work_queue.put((('boilerplate~',), [], '', 1, 0, ''))
 
-            self.cache[cache_key] = {
-                'lines': lines,
-                'modules': modules,
-                'completions': out,
-            }
-
-        if filters:
-            return [x for x in out if x['$type'] in filters]
-        return out
-
-    def format_description(self, raw_desc):
-        description = re.sub('\n|  ', '', raw_desc)
-        if len(description) > self.description_length:
-            description = description[:self.description_length]
-
-        return description
+        if cached:
+            if cached.completions is None:
+                out = self.mix_boilerplate([])
+            elif cache_key[-1] == 'vars':
+                out = self.mix_boilerplate(cached.completions)
+            else:
+                out = cached.completions
+            if filters:
+                out = (x for x in out if x['$type'] in filters)
+            return [x for x in sorted(out, key=sort_key)]
+        return []

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
@@ -1,5 +1,231 @@
 import os
 import re
+import glob
+import json
+import time
+import queue
+import hashlib
+import logging
+import threading
+import subprocess
+from string import whitespace
+
+from deoplete_jedi import utils
+
+_paths = []
+_cache_path = None
+# List of items in the file system cache. `import~` is a special key for
+# caching import modules. It should not be cached to disk.
+_file_cache = set(['import~'])
+
+_cache_lock = threading.RLock()
+_cache = {}
+
+log = logging.getLogger('deoplete.jedi.cache')
+
+# This uses [\ \t] to avoid spanning lines
+_import_re = re.compile(r'''
+    ^[\ \t]*(
+        from[\ \t]+[\w\.]+[\ \t]+import\s+\([\s\w,]+\)|
+        from[\ \t]+[\w\.]+[\ \t]+import[\ \t\w,]+|
+        import[\ \t]+\([\s\w,]+\)|
+        import[\ \t]+[\ \t\w,]+
+    )
+''', re.VERBOSE | re.MULTILINE)
+
+
+class CacheEntry(object):
+    def __init__(self, dict):
+        self.key = tuple(dict.get('cache_key'))
+        self._touched = time.time()
+        self.time = dict.get('time')
+        self.modules = dict.get('modules')
+        self.completions = dict.get('completions')
+        self.refresh = False
+        if self.completions is None:
+            self.refresh = True
+            self.completions = []
+
+    def update_from(self, other):
+        self.key = other.key
+        self.time = other.time
+        self.modules = other.modules
+        self.completions = other.completions
+
+    def touch(self):
+        self._touched = time.time()
+
+    def to_dict(self):
+        return {
+            'cache_key': self.key,
+            'time': self.time,
+            'modules': self.modules,
+            'completions': self.completions,
+        }
+
+
+def get_cache_path():
+    global _cache_path
+    if not _cache_path or not os.path.isdir(_cache_path):
+        p = subprocess.Popen(['python', '-V'], stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        version = re.search(r'(\d+\.\d+)\.', (stdout or stderr).decode('utf8')).group(1)
+        cache_dir = os.getenv('XDG_CACHE_HOME', '~/.cache')
+        cache_dir = os.path.join(os.path.expanduser(cache_dir), 'deoplete/jedi',
+                                 version)
+        if not os.path.exists(cache_dir):
+            umask = os.umask(0)
+            os.makedirs(cache_dir, 0o0700)
+            os.umask(umask)
+        _cache_path = cache_dir
+    return _cache_path
+
+
+def retrieve(key):
+    if not key:
+        return None
+
+    with _cache_lock:
+        if key[-1] == 'package' and key[0] not in _file_cache:
+            # This will only load the cached item from a file the first time it
+            # was seen.
+            cache_file = os.path.join(get_cache_path(), '{}.json'.format(key[0]))
+            if os.path.isfile(cache_file):
+                _file_cache.add(key[0])
+                with open(cache_file, 'rt') as fp:
+                    try:
+                        cached = CacheEntry(json.load(fp))
+                        cached.time = time.time()
+                        _cache[key] = cached
+                        log.debug('Loaded from file: %r', key)
+                        return cached
+                    except Exception:
+                        pass
+        cached = _cache.get(key)
+        if cached:
+            cached.touch()
+        return cached
+
+
+def store(key, value):
+    with _cache_lock:
+        if not isinstance(value, CacheEntry):
+            value = CacheEntry(value)
+
+        if value.refresh:
+            # refresh is set when completions is None.  This will be due to
+            # Jedi producing an error and not getting any completions.  Use any
+            # previously cached completions while a refresh is attempted.
+            old = _cache.get(key)
+            value.completions = old.completions
+
+        _cache[key] = value
+
+        if key[-1] == 'package' and key[0] not in _file_cache:
+            _file_cache.add(key[0])
+            cache_file = os.path.join(get_cache_path(), '{}.json'.format(key[0]))
+            with open(cache_file, 'wt') as fp:
+                json.dump(value.to_dict(), fp)
+                log.debug('Stored to file: %r', key)
+        return value
+
+
+def exists(key):
+    with _cache_lock:
+        return key in _cache
+
+
+def reap_cache(max_age=300):
+    """Clear the cache of old items
+
+    Module level completions are exempt from reaping.  It is assumed that
+    module level completions will have a key length of 1.
+    """
+    with _cache_lock:
+        now = time.time()
+        cur_len = len(_cache)
+        for cached in list(_cache.values()):
+            if cached.key[-1] not in ('package', 'local', 'boilerplate~',
+                                      'import~') \
+                    and now - cached._touched > max_age:
+                _cache.pop(cached.key)
+        return len(_cache), cur_len
+
+
+def cache_processor_thread(compl_queue):
+    last_clear = time.time()
+    while True:
+        now = time.time()
+        if now - last_clear >= 30:
+            after, before = reap_cache()
+            reaped = before - after
+            if reaped > 0:
+                log.debug('Removed %d of %d cache items', reaped, before)
+            last_clear = time.time()
+
+        try:
+            compl = compl_queue.get(timeout=0.01)
+            cache_key = compl.get('cache_key')
+            cached = retrieve(cache_key)
+            if cached is None or cached.time <= compl.get('time'):
+                cached = store(cache_key, compl)
+                log.debug('Processed: %r', cache_key)
+        except queue.Empty:
+            pass
+
+
+def start_background(compl_queue):
+    log.debug('Starting reaper thread')
+    t = threading.Thread(target=cache_processor_thread, args=(compl_queue,))
+    t.daemon = True
+    t.start()
+
+
+# balanced() taken from:
+# http://stackoverflow.com/a/6753172/4932879
+# Modified to include string delimiters
+def _balanced():
+    # Doc strings might be an issue, but we don't care.
+    idelim = iter("""(){}[]""''""")
+    delims = dict(zip(idelim, idelim))
+    odelims = {v: k for k, v in delims.items()}
+    closing = delims.values()
+
+    def balanced(astr):
+        """Test if a string has balanced delimiters.
+
+        Returns a boolean and a string of the opened delimiter.
+        """
+        stack = []
+        skip = False
+        open_d = ''
+        open_str = ''
+        for c in astr:
+            if c == '\\':
+                skip = True
+                continue
+            if skip:
+                skip = False
+                continue
+            d = delims.get(c, None)
+            if d and not open_str:
+                if d in '"\'':
+                    open_str = d
+                open_d = odelims.get(d)
+                stack.append(d)
+            elif c in closing:
+                if c == open_str:
+                    open_str = ''
+                if not open_str and (not stack or c != stack.pop()):
+                    return False, open_d
+                if stack:
+                    open_d = odelims.get(stack[-1])
+                else:
+                    open_d = ''
+        return not stack, open_d
+    return balanced
+balanced = _balanced()
 
 
 def split_module(text, default_value=None):
@@ -7,13 +233,108 @@ def split_module(text, default_value=None):
 
     If there is nothing to split, return `default_value`.
     """
-    m = re.search('([\w_\.]+)$', text)
+    b, d = balanced(text)
+    if not b:
+        # Handles cases where the cursor is inside of unclosed delimiters.
+        # If the input is: re.search(x.spl
+        # The returned value should be: x
+        if d and d not in '\'"':
+            di = text.rfind(d)
+            if di != -1:
+                text = text[di+1:]
+        else:
+            return default_value
+    m = re.search('([\S\.]+)$', text)
     if m and '.' in m.group(1):
         return m.group(1).rsplit('.', 1)[0]
     return default_value
 
 
-def cache_context(filename, context):
+def get_parents(source, line, class_only=False):
+    """Find the parent blocks
+
+    Collects parent blocks that contain the current line to help form a cache
+    key based on variable scope.
+    """
+    parents = []
+    start = line - 1
+    indent = len(source[start]) - len(source[start].lstrip())
+    if class_only:
+        pattern = r'^\s*class\s+(\w+)'
+    else:
+        pattern = r'^\s*(?:def|class)\s+(\w+)'
+
+    for i in range(start, 0, -1):
+        s_line = source[i].lstrip()
+        l_indent = len(source[i]) - len(s_line)
+        if s_line and l_indent < indent:
+            m = re.search(pattern, s_line)
+            indent = l_indent
+            if m:
+                parents.insert(0, m.group(1))
+
+    return parents
+
+
+def full_module(source, obj):
+    """Construct the full module path
+
+    This finds all imports and attempts to reconstruct the full module path.
+    If matched on a standard `import` line, `obj` itself is a full module path.
+    On `from` import lines, the parent module is prepended to `obj`.
+    """
+
+    module = ''
+    obj_pat = r'(?:(\S+)\s+as\s+)?\b{0}\b'.format(re.escape(obj.split('.', 1)[0]))
+    for match in _import_re.finditer('\n'.join(source)):
+        module = ''
+        imp_line = ' '.join(match.group(0).split())
+        if imp_line.startswith('from '):
+            _, module, imp_line = imp_line.split(' ', 2)
+        m = re.search(obj_pat, imp_line)
+        if m:
+            # If the import is aliased, use the alias as part of the key
+            alias = m.group(1)
+            if alias:
+                obj = obj.split('.')
+                obj[0] = alias
+                obj = '.'.join(obj)
+            if module:
+                return '.'.join((module, obj))
+            return obj
+    return None
+
+
+def sys_path(refresh=False):
+    global _paths
+    if not _paths or refresh:
+        p = subprocess.Popen([
+            'python',
+            '-c', r'import sys; print("\n".join(sys.path))',
+        ], stdout=subprocess.PIPE)
+        stdout, _ = p.communicate()
+        _paths = [x for x in stdout.decode('utf8').split('\n')
+                  if x and os.path.isdir(x)]
+    return _paths
+
+
+def is_package(module, refresh=False):
+    """Test if a module path is an installed package
+
+    The current interpreter's sys.path is retrieved on first run.
+    """
+    if re.search(r'[^\w\.]', module):
+        return False
+
+    paths = sys_path(refresh)
+
+    module = module.split('.', 1)[0]
+    pglobs = [os.path.join(x, module, '__init__.py') for x in paths]
+    pglobs.extend([os.path.join(x, '{}.*'.format(module)) for x in paths])
+    return any(map(glob.glob, pglobs))
+
+
+def cache_context(filename, context, source):
     """Caching based on context input.
 
     If the input is blank, it was triggered with `.` to get module completions.
@@ -25,59 +346,87 @@ def cache_context(filename, context):
     filename.  The buffer file's modification time is checked to see if the
     completion needs to be refreshed.  The approximate scope lines are cached
     to help invalidate the cache based on line position.
+
+    Cache keys are made using tuples to make them easier to interpret later.
     """
+    cinput = context['input'].lstrip()
+    if not re.sub(r'[\s\d\.]+', '', cinput):
+        return None, []
+    filename_hash = hashlib.md5(filename.encode('utf8')).hexdigest()
     line = context['position'][1]
-    deoplete_input = context['input'].strip()
+    log.debug('Input: "%s"', cinput)
     cache_key = None
     extra_modules = []
-    cache_line = 0
+    cur_module = os.path.splitext(os.path.basename(filename))[0]
 
-    if deoplete_input.startswith(('import ', 'from ')):
+    if cinput.startswith(('import ', 'from ')):
         # Cache imports with buffer filename as the key prefix.
         # For `from` imports, the first part of the statement is
         # considered to be the same as `import` for caching.
-        suffix = 'import'
 
-        # The trailing whitespace is significant for caching imports.
-        import_line = context['input'].lstrip()
+        import_key = 'import~'
+        cinput = context['input'].lstrip()
+        m = re.search(r'^from\s+(\S+)', cinput)
+        if m:
+            import_key = m.group(1) or 'import~'
+        elif cinput.startswith('import ') and cinput.rstrip().endswith('.'):
+            import_key = re.sub(r'[^\s\w\.]', ' ', cinput.strip()).split()[-1]
 
-        if import_line.startswith('import'):
-            m = re.search(r'^import\s+(\S+)$', import_line)
-        else:
-            m = re.search(r'^from\s+(\S+)\s+import\s+', import_line)
-            if m:
-                # Treat the first part of the import as a cached
-                # module, but cache it per-buffer.
-                cache_key = '{}.from.{}'.format(filename, m.group(1))
+        if import_key:
+            if '.' in import_key and import_key[-1] not in whitespace \
+                    and not re.search(r'^from\s+\S+\s+import', cinput):
+                # Dot completion on the import line
+                import_key, _ = import_key.rsplit('.', 1)
+            import_key = import_key.rstrip('.')
+            module_file = utils.module_search(import_key,
+                                              [os.getcwd(),
+                                               os.path.dirname(filename)])
+            if module_file:
+                cache_key = (import_key, 'local')
+                extra_modules.append(module_file)
+            elif is_package(import_key):
+                cache_key = (import_key, 'package')
             else:
-                m = re.search(r'^from\s+(\S+)$', import_line)
-
-        if not cache_key:
-            if m:
-                suffix = split_module(m.group(1), suffix)
-                cache_key = '{}.import.{}'.format(filename, suffix)
-                if os.path.exists(filename):
-                    extra_modules.append(filename)
+                cache_key = ('import~',)
 
     if not cache_key:
-        # Find a cacheable key first
-        cache_key = split_module(deoplete_input)
-        if cache_key:
-            if cache_key.startswith('self'):
-                # TODO: Get class lines and cache these differently
-                # based on cursor position.
-                # Cache `self.`, but monitor buffer file's modification
-                # time.
+        obj = split_module(cinput.strip())
+        if obj:
+            cache_key = (obj, 'package')
+            if obj.startswith('self'):
                 if os.path.exists(filename):
                     extra_modules.append(filename)
-                cache_key = '{}.{}'.format(filename, cache_key)
-                cache_line = line - 1
-                os.path
-        elif context.get('complete_str'):
-            # Note: Module completions will be an empty string.
-            cache_key = filename
+                # `self` is a special case object that needs a scope included
+                # in the cache key.
+                parents = get_parents(source, line, class_only=True)
+                parents.insert(0, cur_module)
+                cache_key = (filename_hash, tuple(parents), obj)
+            else:
+                module_path = full_module(source, obj)
+                if module_path and not module_path.startswith('.') \
+                        and is_package(module_path):
+                    cache_key = (module_path, 'package')
+                else:
+                    # A quick scan revealed that the dot completion doesn't
+                    # involve an imported module.  Treat it like a scoped
+                    # variable and ensure the cache invalidates when the file
+                    # is saved.
+                    if os.path.exists(filename):
+                        extra_modules.append(filename)
+
+                    module_file = utils.module_search(module_path,
+                                                      [os.path.dirname(filename)])
+                    if module_file:
+                        cache_key = (module_path, 'local')
+                    else:
+                        parents = get_parents(source, line)
+                        parents.insert(0, cur_module)
+                        cache_key = (filename_hash, tuple(parents), obj, 'dot')
+        elif context.get('complete_str') or cinput.rstrip().endswith('='):
+            parents = get_parents(source, line)
+            parents.insert(0, cur_module)
+            cache_key = (filename_hash, tuple(parents), 'vars')
             if os.path.exists(filename):
                 extra_modules.append(filename)
-            cache_line = line - 1
 
-    return cache_key, cache_line, extra_modules
+    return cache_key, extra_modules

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/utils.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/utils.py
@@ -1,0 +1,57 @@
+import os
+import re
+
+import logging
+
+log = logging.getLogger('server')
+
+
+def module_file(dirname, suffix, base):
+    """Find a script that matches the suffix path."""
+    search = os.path.abspath(os.path.join(dirname, suffix))
+    # dirname = os.path.dirname(dirname)
+    found = ''
+    while True:
+        p = os.path.join(search, '__init__.py')
+        if os.path.isfile(p):
+            found = p
+            break
+        p = search + '.py'
+        if os.path.isfile(p):
+            found = p
+            break
+        if os.path.basename(search) == base:
+            break
+        search = os.path.dirname(search)
+    return found
+
+
+def module_search(module, paths):
+    """Search paths for a file matching the module."""
+    if not module:
+        return ''
+
+    base = re.sub(r'\.+', '.', module).strip('.').split('.')[0]
+    module_path = os.path.normpath(re.sub(r'(\.+)', r'/\1/', module).strip('/'))
+    for p in paths:
+        found = module_file(p, module_path, base)
+        if found:
+            return found
+    return ''
+
+
+def jedi_walk(completions, depth=0, max_depth=5):
+    """Walk through Jedi objects
+
+    The purpose for this is to help find an object with a specific name.  Once
+    found, the walking will stop.
+    """
+    for c in completions:
+        yield c
+        if hasattr(c, 'description') and c.type == 'import':
+            d = c.description
+            if d.startswith('from ') and d.endswith('*') and depth < max_depth:
+                # Haven't determined the lowest Python 3 version required.
+                # If we determine 3.3, we can use `yield from`
+                for sub in jedi_walk(c.defined_names(), depth+1, max_depth):
+                    yield sub

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
@@ -1,0 +1,80 @@
+import os
+import json
+import time
+import queue
+import logging
+import threading
+
+from .server import Client
+
+log = logging.getLogger('deoplete.jedi')
+workers = []
+work_queue = queue.Queue()
+comp_queue = queue.Queue()
+
+
+class Worker(threading.Thread):
+    daemon = True
+
+    def __init__(self, in_queue, out_queue, desc_len=0,
+                 short_types=False, show_docstring=False, debug=False):
+        self._client = Client(desc_len, short_types, show_docstring, debug)
+        self.in_queue = in_queue
+        self.out_queue = out_queue
+        super(Worker, self).__init__()
+        self.log = logging.getLogger('deoplete.jedi.%s' % self.name)
+
+    def completion_work(self, cache_key, extra_modules, source, line, col,
+                        filename):
+        completions = self._client.completions(cache_key, source, line, col,
+                                               filename)
+        out = None
+        modules = {f: int(os.path.getmtime(f)) for f in extra_modules}
+        if completions is not None:
+            out = []
+            for c in completions:
+                module_path, name, type_, desc, abbr, kind = c
+                if module_path and module_path not in modules \
+                        and os.path.exists(module_path):
+                    modules[module_path] = int(os.path.getmtime(module_path))
+
+                out.append({
+                    '$type': type_,
+                    'word': name,
+                    'abbr': abbr,
+                    'kind': kind,
+                    'info': desc,
+                    'menu': '[jedi] ',
+                    'dup': 1,
+                })
+
+        return {
+            'cache_key': cache_key,
+            'time': time.time(),
+            'modules': modules,
+            'completions': out,
+        }
+
+    def run(self):
+        while True:
+            try:
+                work = self.in_queue.get(block=False, timeout=0.5)
+                self.log.debug('Got work')
+                self.out_queue.put(self.completion_work(*work), block=False)
+                self.log.debug('Completed work')
+            except queue.Empty:
+                # Sleep is mandatory to avoid pegging the CPU
+                time.sleep(0.01)
+            except Exception:
+                self.log.debug('Worker error', exc_info=True)
+                time.sleep(0.05)
+
+
+def start(count, desc_len=0, short_types=False, show_docstring=False,
+          debug=False):
+    while count:
+        t = Worker(work_queue, comp_queue, desc_len, short_types,
+                   show_docstring, debug)
+        workers.append(t)
+        t.start()
+        count -= 1


### PR DESCRIPTION
- Cache is no longer optional
- Use tuples for cache keys
- Non-object completions are cached by scope
- Module/object completion can occur on any input with periods
- Always refresh scoped variables
- Cache is managed in the cache module
- Reaper thread for clearing old cache items
- MD5 hash for filename portion of cache keys
- Rewrote profiler
- Module completions are cached to a file
- Disable Jedi's cache since cache is managed
- Force a synthetic completion for module caches
- Reuse previous completions on Jedi failure
- Attempt fallback completions when Jedi fails
- Scan current directory for a local module