### PR TITLE
Removed superfluous input pattern

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_jedi.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi.py
@@ -25,7 +25,6 @@ class Source(Base):
         self.rank = 500
         self.filetypes = ['python']
         self.input_pattern = (r'[\w\)\]\}\'\"]+\.\w*$|'
-                              r'\w+\s*=\s*\w*$|'
                               r'^\s*@\w*$|'
                               r'^\s*from\s+[\w\.]*(?:\s+import\s+(?:\w*(?:,\s*)?)*)?|'
                               r'^\s*import\s+(?:[\w\.]*(?:,\s*)?)*')


### PR DESCRIPTION
@Shougo I remember this now.  This was left over from an older implementation of the cache key construction.  At the time, I was confused about `input` vs `complete_str`.

The pattern is superfluous and has been removed.  Check it and merge if it fixes the problem.

Fixes Shougo/deoplete.nvim#301