### PR TITLE
Allow specification of additional module search paths via `g:deoplete#sources#jedi#site_packages`

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_jedi.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi.py
@@ -51,6 +51,9 @@ class Source(Base):
         self.python_path = vars.get(
             'deoplete#sources#jedi#python_path', ''
         )
+        self.site_packages = vars.get(
+            'deoplete#sources#jedi#site_packages', ''
+        ).split(':')
         self.debug_enabled = vars.get(
             'deoplete#sources#jedi#debug_enabled', False
         )
@@ -63,7 +66,8 @@ class Source(Base):
                 cache.python_path = self.python_path
             worker.start(max(1, self.worker_threads), self.statement_length,
                          self.use_short_types, self.show_docstring,
-                         self.debug_enabled, self.python_path)
+                         self.debug_enabled, self.python_path,
+                         self.site_packages)
             cache.start_background(worker.comp_queue)
             self.workers_started = True
 

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/server.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/server.py
@@ -472,15 +472,19 @@ class Client(object):
     max_completion_count = 50
 
     def __init__(self, desc_len=0, short_types=False, show_docstring=False,
-                 debug=False, python_path=None):
+                 debug=False, python_path=None, site_packages=None):
         self._server = None
         self._count = 0
         self.version = (0, 0, 0, 'final', 0)
         self.env = os.environ.copy()
-        self.env.update({
-            'PYTHONPATH': ':'.join((jedi_path,
-                                    os.path.dirname(os.path.dirname(__file__)))),
-        })
+
+        site_packages_paths = [
+            jedi_path,
+            os.path.dirname(os.path.dirname(__file__)),
+        ]
+        if site_packages:
+            site_packages_paths.extend(site_packages)
+        self.env.update({'PYTHONPATH': ':'.join(site_packages_paths)})
 
         if not python_path:
             prog = 'python'

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
@@ -19,9 +19,9 @@ class Worker(threading.Thread):
 
     def __init__(self, in_queue, out_queue, desc_len=0,
                  short_types=False, show_docstring=False, debug=False,
-                 python_path=None):
+                 python_path=None, site_packages=None):
         self._client = Client(desc_len, short_types, show_docstring, debug,
-                              python_path)
+                              python_path, site_packages)
 
         self.in_queue = in_queue
         self.out_queue = out_queue
@@ -75,10 +75,10 @@ class Worker(threading.Thread):
 
 
 def start(count, desc_len=0, short_types=False, show_docstring=False,
-          debug=False, python_path=None):
+          debug=False, python_path=None, site_packages=None):
     while count:
         t = Worker(work_queue, comp_queue, desc_len, short_types,
-                   show_docstring, debug, python_path)
+                   show_docstring, debug, python_path, site_packages)
         workers.append(t)
         t.start()
         count -= 1


### PR DESCRIPTION
In some situations -- in my case, when running nvim within a GUI application -- a virtualenv can't be used for providing additional package paths for completions.  What this change does is allows one to set a specific configuration variable to a colon-delimited list of paths to add to Jedi's `PYTHONPATH`.  For example:

```
let g:deoplete#sources#jedi#site_packages='/some/path/to/a/special/site-packages/directory/'
```

Packages within the above directory would then become available to Jedi for completions.