### PR TITLE
Use blocking modes with Threading queues

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
@@ -169,7 +169,7 @@ def cache_processor_thread(compl_queue):
             last_clear = time.time()
 
         try:
-            compl = compl_queue.get(timeout=0.01)
+            compl = compl_queue.get()
             cache_key = compl.get('cache_key')
             cached = retrieve(cache_key)
             if cached is None or cached.time <= compl.get('time'):

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
@@ -145,29 +145,25 @@ def reap_cache(max_age=300):
     Module level completions are exempt from reaping.  It is assumed that
     module level completions will have a key length of 1.
     """
-    with _cache_lock:
-        now = time.time()
-        cur_len = len(_cache)
-        for cached in list(_cache.values()):
-            if cached.key[-1] not in ('package', 'local', 'boilerplate~',
-                                      'import~') \
-                    and now - cached._touched > max_age:
-                _cache.pop(cached.key)
-        return len(_cache), cur_len
+    while True:
+        time.sleep(300)
+
+        with _cache_lock:
+            now = time.time()
+            cur_len = len(_cache)
+            for cached in list(_cache.values()):
+                if cached.key[-1] not in ('package', 'local', 'boilerplate~',
+                                          'import~') \
+                        and now - cached._touched > max_age:
+                    _cache.pop(cached.key)
+
+            if cur_len - len(_cache) > 0:
+                log.debug('Removed %d of %d cache items', len(_cache), cur_len)
 
 
 def cache_processor_thread(compl_queue):
-    last_clear = time.time()
     errors = 0
     while True:
-        now = time.time()
-        if now - last_clear >= 30:
-            after, before = reap_cache()
-            reaped = before - after
-            if reaped > 0:
-                log.debug('Removed %d of %d cache items', reaped, before)
-            last_clear = time.time()
-
         try:
             compl = compl_queue.get()
             cache_key = compl.get('cache_key')
@@ -176,8 +172,6 @@ def cache_processor_thread(compl_queue):
                 cached = store(cache_key, compl)
                 log.debug('Processed: %r', cache_key)
             errors = 0
-        except queue.Empty:
-            pass
         except Exception as e:
             errors += 1
             if errors > 3:
@@ -188,6 +182,9 @@ def cache_processor_thread(compl_queue):
 def start_background(compl_queue):
     log.debug('Starting reaper thread')
     t = threading.Thread(target=cache_processor_thread, args=(compl_queue,))
+    t.daemon = True
+    t.start()
+    t = threading.Thread(target=reap_cache)
     t.daemon = True
     t.start()
 

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
@@ -62,13 +62,10 @@ class Worker(threading.Thread):
     def run(self):
         while True:
             try:
-                work = self.in_queue.get(block=False, timeout=0.5)
+                work = self.in_queue.get()
                 self.log.debug('Got work')
-                self.out_queue.put(self.completion_work(*work), block=False)
+                self.out_queue.put(self.completion_work(*work), timeout=0.5)
                 self.log.debug('Completed work')
-            except queue.Empty:
-                # Sleep is mandatory to avoid pegging the CPU
-                time.sleep(0.01)
             except Exception:
                 self.log.debug('Worker error', exc_info=True)
                 time.sleep(0.05)

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
@@ -68,7 +68,6 @@ class Worker(threading.Thread):
                 self.log.debug('Completed work')
             except Exception:
                 self.log.debug('Worker error', exc_info=True)
-                time.sleep(0.05)
 
 
 def start(count, desc_len=0, short_types=False, show_docstring=False,


### PR DESCRIPTION
Fixes https://github.com/zchee/deoplete-jedi/issues/61.

I still see a lot of 

> 4678  00:17:41.376867 futex(0x7fe9b0000d90, FUTEX_WAIT_BITSET_PRIVATE|FUTEX_CLOCK_REALTIME, 0, {1474496261, 386816000}, ffffffff) = -1 ETIMEDOUT (Connection timed out)

now, but those appear to be there also without this patch.

And they might even be normal?!

@tweekmonster 
Why have you made the calls non-blocking in the beginning?  0ee56be