### PR TITLE
Cache refactor

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
@@ -1,5 +1,4 @@
 import os
-import json
 import time
 import queue
 import logging
@@ -32,31 +31,18 @@ class Worker(threading.Thread):
                         filename):
         completions = self._client.completions(cache_key, source, line, col,
                                                filename)
-        out = None
         modules = {f: file_mtime(f) for f in extra_modules}
         if completions is not None:
-            out = []
             for c in completions:
-                module_path, name, type_, desc, abbr, kind = c
-                if module_path and module_path not in modules \
-                        and os.path.exists(module_path):
-                    modules[module_path] = file_mtime(module_path)
-
-                out.append({
-                    '$type': type_,
-                    'word': name,
-                    'abbr': abbr,
-                    'kind': kind,
-                    'info': desc,
-                    'menu': '[jedi] ',
-                    'dup': 1,
-                })
+                m = c['module']
+                if m and m not in modules and os.path.exists(m):
+                    modules[m] = file_mtime(m)
 
         return {
             'cache_key': cache_key,
             'time': time.time(),
             'modules': modules,
-            'completions': out,
+            'completions': completions,
         }
 
     def run(self):


### PR DESCRIPTION
Continuing conversation from #70 

@blueyed 

> For entries without a docstring the preview window stays open (which makes sense to avoid flickering, but is not cleared). When selecting an entry with docstring it flickers though (cannot really say if that was the case before though).

I can't say either.  I don't use the preview pane for completions, but I assumed that the buffer not clearing is an issue out of my control.  I guess it might be possible to set the `info` key to a single space to see if that counts as something that can replace the preview contents.

> Then I was not getting any completions anymore (after suspend/hibernate - could that have an influence?!):
> It seems to recover after the "Broken pipe", but there's a delay and it keeps like that.
I suggest creating a PR from your branch to speak on/about the code?!

I'm not sure what's up with that.  What OS are you using?  Could you perhaps reproduce it by doing a bunch of completions, then intentionally suspending?