### PR TITLE
first argument to struct.pack must be bytes in python2.7

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_jedi/server.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/server.py
@@ -95,7 +95,7 @@ def stream_read(pipe):
 def stream_write(pipe, obj):
     """Write data to the pipe."""
     data = pickle.dumps(obj, 2)
-    header = struct.pack('I', len(data))
+    header = struct.pack(b'I', len(data))
     buffer = getattr(pipe, 'buffer', pipe)
     buffer.write(header + data)
     pipe.flush()


### PR DESCRIPTION
This was causing the completion server to fail to start in python2.7 environments:

```
Starting server.
Server Exception.  Shutting down.
Traceback (most recent call last):
  File "/nail/home/mmulder/.config/nvim/plugged/deoplete-jedi/rplugin/python3/deoplete/sources/deoplete_jedi/server.py", line 198, in run
    stream_write(sys.stdout, tuple(sys.version_info))
  File "/nail/home/mmulder/.config/nvim/plugged/deoplete-jedi/rplugin/python3/deoplete/sources/deoplete_jedi/server.py", line 98, in stream_write
    header = struct.pack('I', len(data))
TypeError: Struct() argument 1 must be string, not unicode
```