### PR TITLE
test/flake8: change ignore, max-line-length and max-complexity

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,29 +1,12 @@
-# http://flake8.readthedocs.org/en/latest/config.html
 [flake8]
-# comma-separated filename and glob patterns
-#   default: .svn,CVS,.bzr,.hg,.git,__pycache
 exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,tests/*,rplugin/python3/deoplete/jedi
-
-# comma-separatedd filename and glob patterns
-#   default: *.py
 filename = *.py
-
-# select errors and warnings tot enable which are off by default
-# select =
-
-# skip errers ror warnings.
-# If the `ignore` option is blank, ignore the error codes are
-#   - E123/E133
-#   - E226
-#   - E241/E242
-ignore = D100,D101,D102,D103,D104,D201D201,D202,D203,D204,E402,E123/E133,E226,E241/E242,H101,H301,H304,I100,I201
-
-# set maximum allowed line length
-#   default: 79
-max-line-length = 79
-
-# set the error format
-# format =
-
-# McCable complexity threshold
-max-complexity = 10
+ignore =
+    # E226: missing whitespace around arithmetic operator
+    E226,
+    # E305: expected 2 blank lines after class or function definition, found 0
+    E305,
+    # E402: module level import not at top of file
+    E402
+max-line-length = 99
+max-complexity = 20


### PR DESCRIPTION
formatting by google/yapf and autopep8 for flake8 CI test.

Passes test but need to ignore `E502`.

```sh
./rplugin/python3/deoplete/sources/deoplete_jedi.py:203:75: E502 the backslash is redundant between brackets
./rplugin/python3/deoplete/sources/deoplete_jedi.py:204:61: E502 the backslash is redundant between brackets
./rplugin/python3/deoplete/sources/deoplete_jedi/server.py:361:54: E502 the backslash is redundant between brackets
```

I do not know how to solve it. Please tell me if possible.

**Edit**: If fix it, conflict `E501 line too long (N > 79 characters)`