### PR TITLE
Make the timeout more conservative

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
@@ -54,7 +54,7 @@ class Worker(threading.Thread):
                 self.results = None
                 t = threading.Thread(target=self.completion_work, args=work)
                 t.start()
-                t.join(timeout=10)
+                t.join(timeout=30)
 
                 if self.results:
                     self.out_queue.put(self.results)


### PR DESCRIPTION
The current timeout is 10, which is not enough for tensorflow (a python package) on my macbook.  I set it to 30 in this pull request.