### PR TITLE
Add server_timeout option

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_jedi.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi.py
@@ -37,6 +37,8 @@ class Source(Base):
 
         self.statement_length = vars.get(
             'deoplete#sources#jedi#statement_length', 0)
+        self.server_timeout = vars.get(
+            'deoplete#sources#jedi#server_timeout', 10)
         self.use_short_types = vars.get(
             'deoplete#sources#jedi#short_types', False)
         self.show_docstring = vars.get(
@@ -77,7 +79,7 @@ class Source(Base):
             if self.python_path and 'VIRTUAL_ENV' not in os.environ:
                 cache.python_path = self.python_path
             worker.start(max(1, self.worker_threads), self.statement_length,
-                         self.use_short_types, self.show_docstring,
+                         self.server_timeout, self.use_short_types, self.show_docstring,
                          (log_file, root_log.level), self.python_path)
             cache.start_background(worker.comp_queue)
             self.workers_started = True

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
@@ -16,12 +16,13 @@ comp_queue = queue.Queue()
 class Worker(threading.Thread):
     daemon = True
 
-    def __init__(self, in_queue, out_queue, desc_len=0,
+    def __init__(self, in_queue, out_queue, desc_len=0, server_timeout=10,
                  short_types=False, show_docstring=False, debug=False,
                  python_path=None):
         self._client = Client(desc_len, short_types, show_docstring, debug,
                               python_path)
 
+        self.server_timeout = server_timeout
         self.in_queue = in_queue
         self.out_queue = out_queue
         super(Worker, self).__init__()
@@ -54,7 +55,7 @@ class Worker(threading.Thread):
                 self.results = None
                 t = threading.Thread(target=self.completion_work, args=work)
                 t.start()
-                t.join(timeout=10)
+                t.join(timeout=self.server_timeout)
 
                 if self.results:
                     self.out_queue.put(self.results)
@@ -73,10 +74,10 @@ class Worker(threading.Thread):
                 self.log.debug('Worker error', exc_info=True)
 
 
-def start(count, desc_len=0, short_types=False, show_docstring=False,
-          debug=False, python_path=None):
+def start(count, desc_len=0, server_timeout=10, short_types=False,
+          show_docstring=False, debug=False, python_path=None):
     while count > 0:
-        t = Worker(work_queue, comp_queue, desc_len, short_types,
+        t = Worker(work_queue, comp_queue, desc_len, server_timeout, short_types,
                    show_docstring, debug, python_path)
         workers.append(t)
         t.start()


### PR DESCRIPTION
This pull request is very similar to #124

Current server timeout 10 second is enough to complement using cache. However, it is too short for me to create cache of huge library like pandas. It takes jedi about 60 seconds to create cache of pandas. So I want to set server timeout manually in init.vim with default value 10. 

Example
```vim
let g:deoplete#sources#jedi#server_timeout = 60
```