### PR TITLE
Change the default timeout to 120s

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
@@ -54,7 +54,7 @@ class Worker(threading.Thread):
                 self.results = None
                 t = threading.Thread(target=self.completion_work, args=work)
                 t.start()
-                t.join(timeout=10)
+                t.join(timeout=120)
 
                 if self.results:
                     self.out_queue.put(self.results)


### PR DESCRIPTION
https://github.com/zchee/deoplete-jedi/pull/125#issuecomment-304216689

We cannot remove the timeout feature completely.
So I have changed the timeout to 120s.