### PR TITLE
Fix inccorrect caching of 'from X import Y'

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
@@ -19,7 +19,7 @@ _cache_path = None
 _file_cache = set(['import~'])
 
 # Cache version allows us to invalidate outdated cache data structures.
-_cache_version = 14
+_cache_version = 15
 _cache_lock = threading.RLock()
 _cache = {}
 

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
@@ -378,8 +378,11 @@ def cache_context(filename, context, source, extra_path):
 
         import_key = 'import~'
         cinput = context['input'].lstrip()
-        m = re.search(r'^from\s+(\S+)', cinput)
+        m = re.search(r'^from\s+(\S+)(.*)', cinput)
         if m:
+            if m.group(2).isspace():
+                cache_key = ('importkeyword~', )
+                return cache_key, extra_modules
             import_key = m.group(1) or 'import~'
         elif cinput.startswith('import ') and cinput.rstrip().endswith('.'):
             import_key = re.sub(r'[^\s\w\.]', ' ', cinput.strip()).split()[-1]

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
@@ -380,7 +380,7 @@ def cache_context(filename, context, source, extra_path):
         cinput = context['input'].lstrip()
         m = re.search(r'^from\s+(\S+)(.*)', cinput)
         if m:
-            if m.group(2).isspace() or m.group(2).lstrip() in 'import':
+            if m.group(2).lstrip() in 'import':
                 cache_key = ('importkeyword~', )
                 return cache_key, extra_modules
             import_key = m.group(1) or 'import~'

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
@@ -380,7 +380,7 @@ def cache_context(filename, context, source, extra_path):
         cinput = context['input'].lstrip()
         m = re.search(r'^from\s+(\S+)(.*)', cinput)
         if m:
-            if m.group(2).isspace():
+            if m.group(2).isspace() or m.group(2).lstrip() in 'import':
                 cache_key = ('importkeyword~', )
                 return cache_key, extra_modules
             import_key = m.group(1) or 'import~'


### PR DESCRIPTION
This fixes issue #127 
The source of the problem is the caching of "from X "
For example:
Writing "from django " will autocomplete to the 'import' keyword and cache the result with the the key ('django, 'package')
After writing "from django import ", the cache will return the 'import' keyword instead of the module attributes

This change checks for the case of "from X " and caches the result with the key ('importkeyword~', [])