### PR TITLE
Move setting of python_path to Source.on_init

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_jedi.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi.py
@@ -55,7 +55,7 @@ class Source(Base):
             'deoplete#sources#jedi#worker_threads', 2)
         # Hard coded python interpreter location
         self.python_path = vars.get(
-            'deoplete#sources#jedi#python_path', '')
+            'deoplete#sources#jedi#python_path', 'python')
         self.extra_path = vars.get(
             'deoplete#sources#jedi#extra_path', [])
 
@@ -80,9 +80,10 @@ class Source(Base):
 
         if not self.workers_started:
             cache.python_path = self.python_path
-            worker.start(max(1, self.worker_threads), self.statement_length,
-                         self.server_timeout, self.use_short_types, self.show_docstring,
-                         (log_file, root_log.level), self.python_path)
+            worker.start(self.python_path, max(1, self.worker_threads),
+                         self.statement_length, self.server_timeout,
+                         self.use_short_types, self.show_docstring,
+                         (log_file, root_log.level))
             cache.start_background(worker.comp_queue)
             self.workers_started = True
 

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
@@ -23,7 +23,8 @@ _cache_version = 16
 _cache_lock = threading.RLock()
 _cache = {}
 
-python_path = 'python'
+# Python program to use, gets set from Source.on_init.
+python_path = None
 
 log = logging.getLogger('deoplete.jedi.cache')
 

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/server.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/server.py
@@ -466,15 +466,13 @@ class Client(object):
     """
     max_completion_count = 50
 
-    def __init__(self, desc_len=0, short_types=False, show_docstring=False,
-                 debug=False, python_path=None):
+    def __init__(self, python_path, desc_len=0, short_types=False, show_docstring=False,
+                 debug=False):
         self._server = None
         self.restarting = threading.Lock()
         self.version = (0, 0, 0, 'final', 0)
         self.env = os.environ.copy()
         self.env.update({'PYTHONPATH': self._make_pythonpath()})
-
-        python_path = python_path or 'python'
 
         self.cmd = [python_path, '-u', os.path.normpath(__file__),
                     '--desc-length', str(desc_len)]

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py
@@ -19,12 +19,11 @@ class Worker(threading.Thread):
     """Exception info being set in threads."""
     daemon = True
 
-    def __init__(self, in_queue, out_queue, desc_len=0, server_timeout=10,
-                 short_types=False, show_docstring=False, debug=False,
-                 python_path=None):
-        self._client = Client(desc_len, short_types, show_docstring, debug,
-                              python_path)
-
+    def __init__(self, python_path, in_queue, out_queue, desc_len=0,
+                 server_timeout=10, short_types=False, show_docstring=False,
+                 debug=False):
+        self._client = Client(python_path, desc_len, short_types,
+                              show_docstring, debug)
         self.server_timeout = server_timeout
         self.in_queue = in_queue
         self.out_queue = out_queue
@@ -93,11 +92,11 @@ class Worker(threading.Thread):
             raise self._exc_info[1]
 
 
-def start(count, desc_len=0, server_timeout=10, short_types=False,
-          show_docstring=False, debug=False, python_path=None):
+def start(python_path, count, desc_len=0, server_timeout=10, short_types=False,
+          show_docstring=False, debug=False):
     while count > 0:
-        t = Worker(work_queue, comp_queue, desc_len, server_timeout, short_types,
-                   show_docstring, debug, python_path)
+        t = Worker(python_path, work_queue, comp_queue, desc_len,
+                   server_timeout, short_types, show_docstring, debug)
         workers.append(t)
         t.start()
         log.debug('Started worker: %r', t)


### PR DESCRIPTION
This now also sets it to the full path in the cache module when
`$VIRTUAL_ENV` is in use.

It makes it the first positional argument with all involved classes,
since it is a required argument really.

TODO:
- [ ] squash-merge