### PR TITLE
Remove special handling of VIRTUAL_ENV for Client.python_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ git submodule update --init
   Default: `0`
 - `g:deoplete#sources#jedi#python_path`: Set the Python interpreter path to use
   for the completion server.  deoplete-jedi uses the first available `python`
-  in `$PATH`.  Use this only if you want use a specific Python interpreter.
-  This has no effect if `$VIRTUAL_ENV` is present in the environment.
+  in `$PATH` otherwise.
   **Note**: This is completely unrelated to configuring Neovim.
 - `g:deoplete#sources#jedi#debug_server`: Enable logging from the server.  If
   set to `1`, server messages are emitted to Deoplete's log file.  This can

--- a/rplugin/python3/deoplete/sources/deoplete_jedi.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi.py
@@ -77,8 +77,7 @@ class Source(Base):
             child_log.propagate = False
 
         if not self.workers_started:
-            if self.python_path and 'VIRTUAL_ENV' not in os.environ:
-                cache.python_path = self.python_path
+            cache.python_path = self.python_path
             worker.start(max(1, self.worker_threads), self.statement_length,
                          self.server_timeout, self.use_short_types, self.show_docstring,
                          (log_file, root_log.level), self.python_path)

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/server.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/server.py
@@ -472,16 +472,9 @@ class Client(object):
         self.env = os.environ.copy()
         self.env.update({'PYTHONPATH': self._make_pythonpath()})
 
-        if 'VIRTUAL_ENV' in os.environ:
-            prog = os.path.join(
-                self.env['VIRTUAL_ENV'],
-                ('Scripts' if os.name == 'nt' else 'bin'), 'python')
-        elif python_path:
-            prog = python_path
-        else:
-            prog = 'python'
+        python_path = python_path or 'python'
 
-        self.cmd = [prog, '-u', os.path.normpath(__file__),
+        self.cmd = [python_path, '-u', os.path.normpath(__file__),
                     '--desc-length', str(desc_len)]
         if short_types:
             self.cmd.append('--short-types')


### PR DESCRIPTION
This is confusing in general, and typically `python` would be the one
from an activated VIRTUAL_ENV already.

Also it is unnecessary / even more confusing with Jedi's new environment
handling (0.12+).

Conflicts with https://github.com/zchee/deoplete-jedi/pull/160, but is a good first step - #160 would then be rebased.