### PR TITLE
Improve handling of errors from worker/client threads

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_jedi.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi.py
@@ -4,10 +4,12 @@ import re
 import sys
 import time
 
+from deoplete.exceptions import SourceInitError
 from deoplete.util import getlines
 
 sys.path.insert(1, os.path.dirname(__file__))  # noqa: E261
-from deoplete_jedi import cache, profiler, utils, worker
+from deoplete_jedi import cache, profiler, utils, worker  # isort:skip
+from deoplete_jedi.server import ServerError  # isort:skip
 
 from .base import Base
 
@@ -166,8 +168,38 @@ class Source(Base):
             return [self.finalize(x) for x in sorted(out, key=sort_key)]
         return []
 
+    @classmethod
+    def _ensure_workers_are_alive(cls):
+        """Ensure that workers are alive.
+
+        Retrieves exception info for non-alive workers, and throws
+        ``SourceInitError`` in case no workers are left.
+        """
+        report_exc = None
+        for w in worker.workers:
+            if w.is_alive():
+                continue
+            try:
+                w.join()
+            except Exception as exc:
+                if not report_exc:
+                    report_exc = exc
+                w.log.warn('Worker %r died: %r' % (w, exc), exc_info=True)
+            worker.workers.remove(w)
+        if not worker.workers:
+            msg = 'All workers have crashed.  First exception: '
+            if isinstance(report_exc, ServerError):
+                stderr = report_exc.args[1]
+                stderr = '\n' + stderr if stderr else ''
+                msg += '%s, stderr=[%s]' % (report_exc.args[0], stderr)
+            else:
+                msg += repr(report_exc)
+            raise SourceInitError(msg)
+
     @profiler.profile
     def gather_candidates(self, context):
+        self._ensure_workers_are_alive()
+
         refresh_boilerplate = False
         if not self.boilerplate:
             bp = cache.retrieve(('boilerplate~',))

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/server.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/server.py
@@ -226,6 +226,7 @@ class Server(object):
             log.debug('Input closed.  Shutting down.')
         except Exception:
             log.exception('Server Exception.  Shutting down.')
+            sys.exit(1)
 
     def find_extra_sys_path(self, filename):
         """Find the file's "root"


### PR DESCRIPTION
Retrieve exceptions from threads and report them

This ensures that there are workers alive in `gather_candidates`, and
handles exceptions from the worker threads (especially `ServerError`).

This will display the following error:

> [deoplete] Error when loading source jedi: All workers have crashed.  First exception: Server exited with 1., stderr=[]. Ignoring.

With #177 it will display:

> [[deoplete] Error when loading source jedi: All workers have crashed.  First exception: Server exited with 1., stderr=[
> 2018-07-06 02:26:27,470 ERROR    [30059] (deoplete.jedi.server) Server Exception.  Shutting down.
> Traceback (most recent call last):
>   File "/home/user/.vim/plugged/deoplete-jedi/rplugin/python3/deoplete/sources/deoplete_jedi/server.py", line 225, in run
>     self._loop()
>   File "/home/user/.vim/plugged/deoplete-jedi/rplugin/python3/deoplete/sources/deoplete_jedi/server.py", line 159, in _loop
>     from jedi.evaluate.sys_path import _get_venv_sitepackages
> ImportError: cannot import name '_get_venv_sitepackages'
]. Ignoring.
