### PR TITLE
Fix synthetic completions

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_jedi.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi.py
@@ -257,12 +257,12 @@ class Source(Base):
 
         if (not cached or refresh) and cache_key and cache_key[-1] == 'package':
             # Create a synthetic completion for a module import as a fallback.
-            synthetic_src = ['import {0}; {0}.'.format(cache_key[0])]
+            synthetic_src = 'import {0}; {0}.'.format(cache_key[0])
             options.update({
                 'synthetic': {
                     'src': synthetic_src,
                     'line': 1,
-                    'col': len(synthetic_src[0]),
+                    'col': len(synthetic_src),
                 }
             })
 

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/cache.py
@@ -19,7 +19,7 @@ _cache_path = None
 _file_cache = set(['import~'])
 
 # Cache version allows us to invalidate outdated cache data structures.
-_cache_version = 16
+_cache_version = 17
 _cache_lock = threading.RLock()
 _cache = {}
 

--- a/rplugin/python3/deoplete/sources/deoplete_jedi/server.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi/server.py
@@ -210,6 +210,8 @@ class Server(object):
 
             if not out and cache_key[-1] in ('package', 'local'):
                 # The backup plan
+                # TODO(blueyed): remove this (far too less results for e.g.
+                # numpy), or at least do not cache it to disk.
                 log.debug('Fallback to module completions')
                 try:
                     out = self.module_completions(cache_key[0], sys.path)


### PR DESCRIPTION
They are used as a fallback for when normal completion fails, but they
fail themselves:

    2018-07-09 05:47:34,305 DEBUG    [24479] (deoplete.jedi.server) calling jedi.Script: Line: 312, Col: 14, Filename: '…/vim/plugged/deoplete-jedi/rplugin/python3/deoplete/sources/deoplete_jedi/server.py'
    2018-07-09 05:47:34,319 DEBUG    [24479] (deoplete.jedi.server) Using synthetic completion: {'src': ['import numpy; numpy.'], 'line': 1, 'col': 20}
    2018-07-09 05:47:34,319 DEBUG    [24479] (deoplete.jedi.server) calling jedi.Script: Line: 1, Col: 20, Filename: '…/vim/plugged/deoplete-jedi/rplugin/python3/deoplete/sources/deoplete_jedi/server.py'
    2018-07-09 05:47:34,320 WARNING  [24479] (deoplete.jedi.server) Failed completion 'script_completion'
    Traceback (most recent call last):
      File "/home/user/.vim/plugged/deoplete-jedi/rplugin/python3/deoplete/sources/deoplete_jedi/server.py", line 132, in wrapper
        return func(self, source, *args, **kwargs)
      File "/home/user/.vim/plugged/deoplete-jedi/rplugin/python3/deoplete/sources/deoplete_jedi/server.py", line 311, in script_completion
        completions = jedi.Script(source, line, col, filename).completions()
      File "/home/user/.vim/plugged/deoplete-jedi/rplugin/python3/deoplete/vendored/jedi/jedi/api/__init__.py", line 93, in __init__
        self._source = python_bytes_to_unicode(source, encoding, errors='replace')
      File "/home/user/.vim/plugged/deoplete-jedi/rplugin/python3/deoplete/vendored/parso/parso/utils.py", line 84, in python_bytes_to_unicode
        encoding = detect_encoding()
      File "/home/user/.vim/plugged/deoplete-jedi/rplugin/python3/deoplete/vendored/parso/parso/utils.py", line 67, in detect_encoding
        if source.startswith(byte_mark):
    AttributeError: 'list' object has no attribute 'startswith'
    2018-07-09 05:47:34,320 DEBUG    [24479] (deoplete.jedi.server) Fallback to module completions
    2018-07-09 05:47:34,321 DEBUG    [24479] (deoplete.jedi.server) Found script for fallback completions: '/usr/lib/python3.6/site-packages/numpy/__init__.py'
    2018-07-09 05:47:34,321 DEBUG    [24479] (deoplete.jedi.server) Remainder to match: ('numpy',)

The problem is that `jedi.Script` expects a string, and not a list.

This code was last changed in e59fe25
(https://github.com/zchee/deoplete-jedi/pull/114), but it was a list
before already, and the fix was likely something else from there
(probably `parse_completion`).

Side note: "col" was wrong before this commit even.

This might have gone unnoticed for so long, because:

1. normally the first method would return something already (it is
   unclear why it did not in this case)
2. appears only in the logs with DEBUG level, and
3. there is another fallback later

Unfortunately the 2nd fallback (`module_completions`) is less
good, and causes e.g. far too less completions for `numpy.`, buts will
get cached to disk anyway.

Therefore I am bumping the cache version for incorrect versions to get
pruned.