### PR TITLE
fixing `completions` not defined on jedi error and removing unused code

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_jedi.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi.py
@@ -171,9 +171,7 @@ class Source(Base):
         except BaseException:
             if not self.ignore_errors:
                 raise
-        except Exception:
-            if not self.ignore_errors:
-                raise
+            return []
 
         return self.finalize_completions(completions)
 


### PR DESCRIPTION
When ignoring errors and an exception is raised,` completions` is not defined thus leading to another error in deoplete-jedi. Instead, I return an empty list for the completions on error.

I also removed the `except Exception` as `Exception` is a subclass of `BaseException` so that the line would never be triggered.